### PR TITLE
Fix missing vector include

### DIFF
--- a/ESPRandom.h
+++ b/ESPRandom.h
@@ -9,6 +9,7 @@
 #include <WiFi.h>
 
 #include <chrono>
+#include <vector>
 
 class ESPRandom {
  public:


### PR DESCRIPTION
Why:

- Allow compile on newer Arduino core releases

This change addresses the need by:

- Adding the vector include