### PR TITLE
Fix compile on ESP8266

### DIFF
--- a/ESPRandom.h
+++ b/ESPRandom.h
@@ -6,7 +6,11 @@
 #define ESPRandom_h
 
 #include <Arduino.h>
-#include <WiFi.h>
+#ifdef ESP32
+#include "WiFi.h"
+#elif defined(ESP8266)
+#include "ESP8266WiFi.h"
+#endif
 
 #include <chrono>
 #include <vector>


### PR DESCRIPTION
Why:

- Allow the library to be compiled for ESP8266 boards

This change addresses the need by:

- Updating the ESP8266 includes